### PR TITLE
Fix model name from glm4.6 to glm-4.6

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -24,7 +24,7 @@ const __dirname = dirname(__filename);
 // Configuration
 const DEFAULT_PORT = process.env.PORT || 4567;
 const DEFAULT_HOST = process.env.HOST || '127.0.0.1';
-const DEFAULT_MODEL = process.env.GLM_MODEL || 'glm4.6';
+const DEFAULT_MODEL = process.env.GLM_MODEL || 'glm-4.6';
 const PID_FILE = join(__dirname, '..', '.glmproxy.pid');
 
 // Claude Code environment overrides


### PR DESCRIPTION
## Summary
Fixes the default model name in the CLI from `glm4.6` to `glm-4.6` to match the GLM API format.

## Changes
- Updated `src/cli.js:27` to use correct model name with hyphen
- Resolves "Unknown Model" errors when using `ccglm` command

## Issue
Fixes #1

## Testing
- Verified that `ccglm` now works without "Unknown Model" error
- Model name matches GLM API expectations (`glm-4.6` and `glm-4.6v`)