### PR TITLE
docs: update `README` - `ANTHROPIC_DEFAULT_*_MODEL` → `glm4.7`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ When you run `ccglm`, it:
 2. Sets environment variables to route Claude Code through the proxy:
    - `ANTHROPIC_BASE_URL` → proxy URL
    - `ANTHROPIC_AUTH_TOKEN` → dummy token (proxy uses your ZAI_API_KEY)
-   - `ANTHROPIC_DEFAULT_*_MODEL` → glm4.6 for all model tiers
+   - `ANTHROPIC_DEFAULT_*_MODEL` → `glm-4.7` for all model tiers
 3. Launches Claude Code
 
 Use `ccglm yolo` to skip permission prompts.


### PR DESCRIPTION
As of https://github.com/dejay2/glmproxy/commit/1c0c4d50f994abecee48a943284bc97000072d81#diff-a3751a8ca1ab5bdf5d4bb6b4c3861d9a81205bc01b080e57301090b6e8b34165R27, `glm4.7` is the default